### PR TITLE
fix: do not force mixin booting

### DIFF
--- a/src/mixin.ts
+++ b/src/mixin.ts
@@ -22,7 +22,7 @@ export default function selectRelatedMixin<
         public $sideloadedRelationParent?: InstanceType<LucidModel>
 
         public static boot() {
-            if (this.booted) {
+            if (this.hasOwnProperty('booted') && this.booted === true) {
                 return
             }
 

--- a/src/mixin.ts
+++ b/src/mixin.ts
@@ -21,6 +21,19 @@ export default function selectRelatedMixin<
         public $sideloadedRelations?: SideloadedRelations<any>
         public $sideloadedRelationParent?: InstanceType<LucidModel>
 
+        public static boot() {
+            if (this.booted) {
+                return
+            }
+
+            super.boot()
+
+            this.before('find', this.$processSideloadedRelationsBeforeQuery)
+            this.before('fetch', this.$processSideloadedRelationsBeforeQuery)
+            this.after('find', this.$processSideloadedRelationsAfterFind)
+            this.after('fetch', this.$processSideloadedRelationsAfterFetch)
+        }
+
         /**
          * Function to pass the sideloaded relations to every row using
          * {@link ModelQueryBuilderContract.rowTransformer}. Also, selects columns
@@ -155,24 +168,6 @@ export default function selectRelatedMixin<
             }
         }
     }
-
-    SelectRelatedMixin.boot()
-    SelectRelatedMixin.before(
-        'find',
-        SelectRelatedMixin.$processSideloadedRelationsBeforeQuery
-    )
-    SelectRelatedMixin.before(
-        'fetch',
-        SelectRelatedMixin.$processSideloadedRelationsBeforeQuery
-    )
-    SelectRelatedMixin.after(
-        'find',
-        SelectRelatedMixin.$processSideloadedRelationsAfterFind
-    )
-    SelectRelatedMixin.after(
-        'fetch',
-        SelectRelatedMixin.$processSideloadedRelationsAfterFetch
-    )
 
     return SelectRelatedMixin
 }


### PR DESCRIPTION
This package is forcing the SelectRelated mixin to boot, thus other mixins won't use the correct table name. If we force the mixin to boot, all other mixins will use "select_related_mixins" table name and will have some problems with static attributes. This PR aims to fix this behavior.

All tests are green.